### PR TITLE
Immediate listing refresh after edit

### DIFF
--- a/TheChopYard/HomeFeedView.swift
+++ b/TheChopYard/HomeFeedView.swift
@@ -78,9 +78,13 @@ struct HomeFeedView: View {
             print("HomeFeedView: User UID changed or view appeared, fetching initial listings.")
             await appViewModel.fetchListings(categories: selectedCategories, sortBy: selectedSort, loadMore: false)
         }
-        .onReceive(NotificationCenter.default.publisher(for: .listingUpdated).receive(on: RunLoop.main)) { _ in
-            Task {
-                await appViewModel.fetchListings(categories: selectedCategories, sortBy: selectedSort, loadMore: false)
+        .onReceive(NotificationCenter.default.publisher(for: .listingUpdated).receive(on: RunLoop.main)) { notification in
+            if let updated = notification.object as? Listing {
+                appViewModel.updateListing(updated)
+            } else {
+                Task {
+                    await appViewModel.fetchListings(categories: selectedCategories, sortBy: selectedSort, loadMore: false)
+                }
             }
         }
         .onAppear {

--- a/TheChopYard/MyListingsView.swift
+++ b/TheChopYard/MyListingsView.swift
@@ -60,8 +60,13 @@ struct MyListingsView: View {
         } message: { listing in
             Text("Are you sure you want to delete \"\(listing.title)\"? This cannot be undone.")
         }
-        .onReceive(NotificationCenter.default.publisher(for: .listingUpdated).receive(on: RunLoop.main)) { _ in
-            onRefresh()
+        .onReceive(NotificationCenter.default.publisher(for: .listingUpdated).receive(on: RunLoop.main)) { notification in
+            if let updated = notification.object as? Listing,
+               let index = userListings.firstIndex(where: { $0.id == updated.id }) {
+                userListings[index] = updated
+            } else {
+                onRefresh()
+            }
         }
     }
 

--- a/TheChopYard/ProfileView.swift
+++ b/TheChopYard/ProfileView.swift
@@ -94,9 +94,12 @@ struct ProfileView: View {
                 await loadProfileData()
             }
             .sheet(item: $selectedListing) { listingToEdit in
-                EditListingView(listing: listingToEdit, onSave: {
+                EditListingView(listing: listingToEdit) { updated in
+                    if let index = userListings.firstIndex(where: { $0.id == updated.id }) {
+                        userListings[index] = updated
+                    }
                     Task { await fetchUserListings() }
-                })
+                }
                 .environmentObject(appViewModel)
             }
             .alert("Log Out", isPresented: $showingLogoutAlert) {


### PR DESCRIPTION
## Summary
- adjust `EditListingView` to emit updated `Listing` objects
- listen for updated listing objects in `AppViewModel`
- update listing arrays in `HomeFeedView`, `MyListingsView` and `ProfileView`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855e8ea6e04832c81c604ec9cf4dcc6