### PR TITLE
Fix listing updates across views

### DIFF
--- a/TheChopYard/AppViewModel.swift
+++ b/TheChopYard/AppViewModel.swift
@@ -231,6 +231,7 @@ class AppViewModel: ObservableObject {
     func updateListing(_ listing: Listing) {
         if let index = listings.firstIndex(where: { $0.id == listing.id }) {
             listings[index] = listing
+            listings.sort { $0.timestamp > $1.timestamp }
         }
     }
 

--- a/TheChopYard/ListingDetailView.swift
+++ b/TheChopYard/ListingDetailView.swift
@@ -5,7 +5,7 @@ import CoreLocation
 
 @MainActor
 struct ListingDetailView: View {
-    let listing: Listing
+    @State var listing: Listing
     @EnvironmentObject var appViewModel: AppViewModel
 
     @State private var sellerUsername: String = "Loading..."
@@ -77,6 +77,11 @@ struct ListingDetailView: View {
         .task {
             await fetchSellerUsername()
             localLocationManager.requestPermissionAndFetchLocation()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .listingUpdated).receive(on: RunLoop.main)) { notification in
+            if let updated = notification.object as? Listing, updated.id == listing.id {
+                listing = updated
+            }
         }
         .navigationDestination(isPresented: $navigateToChat) {
             if let chatId = chatDocumentIdToNavigate {


### PR DESCRIPTION
## Summary
- keep home feed sorted when a listing is edited
- update ListingDetailView to listen for listing updates

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6855f0e9147c832ca94680f65e1397d1