### PR TITLE
Fix feed listing updates

### DIFF
--- a/TheChopYard/AppViewModel.swift
+++ b/TheChopYard/AppViewModel.swift
@@ -231,8 +231,14 @@ class AppViewModel: ObservableObject {
     func updateListing(_ listing: Listing) {
         if let index = listings.firstIndex(where: { $0.id == listing.id }) {
             listings[index] = listing
-            listings.sort { $0.timestamp > $1.timestamp }
+        } else {
+            // If the listing wasn't already in the current page, insert it so
+            // that other views can reflect the latest data without a full refetch.
+            listings.insert(listing, at: 0)
         }
+
+        // Keep listings sorted by newest timestamp after the update/insert.
+        listings.sort { $0.timestamp > $1.timestamp }
     }
 
     func refreshListing(id: String) async {


### PR DESCRIPTION
## Summary
- insert new listings into the feed if they weren't previously loaded
- refresh listing details when the detail view appears

## Testing
- `swiftc -parse TheChopYard/AppViewModel.swift TheChopYard/ListingDetailView.swift TheChopYard/Listing.swift`
- `swift --version`
- `xcodebuild -list -project TheChopYard.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855faa849d0832ca482a96ca425afaf