### PR TITLE
Fix feed listing updates

### DIFF
--- a/TheChopYard/AppViewModel.swift
+++ b/TheChopYard/AppViewModel.swift
@@ -231,8 +231,14 @@ class AppViewModel: ObservableObject {
     func updateListing(_ listing: Listing) {
         if let index = listings.firstIndex(where: { $0.id == listing.id }) {
             listings[index] = listing
-            listings.sort { $0.timestamp > $1.timestamp }
+        } else {
+            // If the listing wasn't already in the current page, insert it so
+            // that other views can reflect the latest data without a full refetch.
+            listings.insert(listing, at: 0)
         }
+
+        // Keep listings sorted by newest timestamp after the update/insert.
+        listings.sort { $0.timestamp > $1.timestamp }
     }
 
     func refreshListing(id: String) async {

--- a/TheChopYard/EditListingView.swift
+++ b/TheChopYard/EditListingView.swift
@@ -303,7 +303,8 @@ struct EditListingView: View {
             updatedListing.imageUrls = finalImageUrlsToSave
 
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .listingUpdated, object: updatedListing)
+                appViewModel.updateListing(updatedListing)
+                NotificationCenter.default.post(name: .listingUpdated, object: listingID)
                 onSave?(updatedListing)
             }
             triggerAlert(title: "Success", message: "Listing updated successfully!")

--- a/TheChopYard/ListingDetailView.swift
+++ b/TheChopYard/ListingDetailView.swift
@@ -77,10 +77,13 @@ struct ListingDetailView: View {
         .task {
             await fetchSellerUsername()
             localLocationManager.requestPermissionAndFetchLocation()
+            await fetchLatestListing()
         }
         .onReceive(NotificationCenter.default.publisher(for: .listingUpdated).receive(on: RunLoop.main)) { notification in
             if let updated = notification.object as? Listing, updated.id == listing.id {
                 listing = updated
+            } else if let id = notification.object as? String, id == listing.id {
+                Task { await fetchLatestListing() }
             }
         }
         .navigationDestination(isPresented: $navigateToChat) {
@@ -235,5 +238,18 @@ struct ListingDetailView: View {
             throw NSError(domain: "FetchUsername", code: 404, userInfo: [NSLocalizedDescriptionKey: "Username not found for UID: \(uid)"])
         }
         return username
+    }
+
+    private func fetchLatestListing() async {
+        guard let id = listing.id else { return }
+        do {
+            let snapshot = try await db.collection("listings").document(id).getDocument()
+            if let updated = try? snapshot.data(as: Listing.self) {
+                listing = updated
+                appViewModel.updateListing(updated)
+            }
+        } catch {
+            print("ListingDetailView: Failed to fetch latest listing: \(error.localizedDescription)")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- insert new listings into the feed if they weren't previously loaded
- refresh listing details when the detail view appears
- refresh from Firestore when a listing is edited

## Testing
- `swiftc -parse TheChopYard/AppViewModel.swift TheChopYard/ListingDetailView.swift TheChopYard/Listing.swift TheChopYard/EditListingView.swift`
- `swift --version`
- `xcodebuild -list -project TheChopYard.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855faa849d0832ca482a96ca425afaf