### PR TITLE
Fix feed listing updates

### DIFF
--- a/TheChopYard/EditListingView.swift
+++ b/TheChopYard/EditListingView.swift
@@ -303,7 +303,8 @@ struct EditListingView: View {
             updatedListing.imageUrls = finalImageUrlsToSave
 
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: .listingUpdated, object: updatedListing)
+                appViewModel.updateListing(updatedListing)
+                NotificationCenter.default.post(name: .listingUpdated, object: listingID)
                 onSave?(updatedListing)
             }
             triggerAlert(title: "Success", message: "Listing updated successfully!")

--- a/TheChopYard/HomeFeedView.swift
+++ b/TheChopYard/HomeFeedView.swift
@@ -81,6 +81,8 @@ struct HomeFeedView: View {
         .onReceive(NotificationCenter.default.publisher(for: .listingUpdated).receive(on: RunLoop.main)) { notification in
             if let updated = notification.object as? Listing {
                 appViewModel.updateListing(updated)
+            } else if let id = notification.object as? String {
+                Task { await appViewModel.refreshListing(id: id) }
             } else {
                 Task {
                     await appViewModel.fetchListings(categories: selectedCategories, sortBy: selectedSort, loadMore: false)

--- a/TheChopYard/ListingDetailView.swift
+++ b/TheChopYard/ListingDetailView.swift
@@ -77,10 +77,13 @@ struct ListingDetailView: View {
         .task {
             await fetchSellerUsername()
             localLocationManager.requestPermissionAndFetchLocation()
+            await fetchLatestListing()
         }
         .onReceive(NotificationCenter.default.publisher(for: .listingUpdated).receive(on: RunLoop.main)) { notification in
             if let updated = notification.object as? Listing, updated.id == listing.id {
                 listing = updated
+            } else if let id = notification.object as? String, id == listing.id {
+                Task { await fetchLatestListing() }
             }
         }
         .navigationDestination(isPresented: $navigateToChat) {
@@ -235,5 +238,18 @@ struct ListingDetailView: View {
             throw NSError(domain: "FetchUsername", code: 404, userInfo: [NSLocalizedDescriptionKey: "Username not found for UID: \(uid)"])
         }
         return username
+    }
+
+    private func fetchLatestListing() async {
+        guard let id = listing.id else { return }
+        do {
+            let snapshot = try await db.collection("listings").document(id).getDocument()
+            if let updated = try? snapshot.data(as: Listing.self) {
+                listing = updated
+                appViewModel.updateListing(updated)
+            }
+        } catch {
+            print("ListingDetailView: Failed to fetch latest listing: \(error.localizedDescription)")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- insert new listings into the feed if they weren't previously loaded
- refresh listing details when the detail view appears
- refresh from Firestore when a listing is edited
- handle listing ID notifications and refresh single listings

## Testing
- `swiftc -parse TheChopYard/AppViewModel.swift TheChopYard/ListingDetailView.swift TheChopYard/Listing.swift TheChopYard/EditListingView.swift TheChopYard/HomeFeedView.swift`
- `swift --version`
- `xcodebuild -list -project TheChopYard.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855faa849d0832ca482a96ca425afaf