### PR TITLE
Fix home feed refresh when home tab selected

### DIFF
--- a/TheChopYard/Extensions.swift
+++ b/TheChopYard/Extensions.swift
@@ -14,4 +14,5 @@ extension Date {
 
 extension Notification.Name {
     static let listingUpdated = Notification.Name("listingUpdated")
+    static let homeTabSelected = Notification.Name("homeTabSelected")
 }

--- a/TheChopYard/HomeFeedView.swift
+++ b/TheChopYard/HomeFeedView.swift
@@ -64,6 +64,12 @@ struct HomeFeedView: View {
         .onDisappear {
             listingListener?.remove()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .homeTabSelected)) { _ in
+            Task {
+                await refreshListings()
+                startLiveListingListener()
+            }
+        }
     }
 
     private func startLiveListingListener() {
@@ -80,6 +86,14 @@ struct HomeFeedView: View {
                 appViewModel.listings = updatedListings
             }
         }
+    }
+
+    private func refreshListings() async {
+        await appViewModel.fetchListings(
+            categories: selectedCategories,
+            sortBy: selectedSort,
+            loadMore: false
+        )
     }
 
     private var listingsScrollView: some View {

--- a/TheChopYard/HomeView.swift
+++ b/TheChopYard/HomeView.swift
@@ -40,6 +40,13 @@ struct HomeView: View {
                     .tag(4)
             }
 
+            // Notify when Home tab is selected
+            .onChange(of: selectedTab) { newValue in
+                if newValue == 0 {
+                    NotificationCenter.default.post(name: .homeTabSelected, object: nil)
+                }
+            }
+
             // Red dot overlay on Messages tab
             if appViewModel.hasUnreadMessages && selectedTab != 1 {
                 GeometryReader { geometry in


### PR DESCRIPTION
## Summary
- create new `homeTabSelected` notification
- post `homeTabSelected` from `HomeView` when switching to the Home tab
- listen for the notification in `HomeFeedView` and fetch fresh listings

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6856104fea54832c9b4767ec8122f8d4