### PR TITLE
Fix chat visibility when thread is deleted

### DIFF
--- a/TheChopYard/ChatView.swift
+++ b/TheChopYard/ChatView.swift
@@ -13,6 +13,7 @@ struct Message: Identifiable, Codable {
 struct ChatView: View {
     let chatId: String
     let sellerUsername: String
+    let otherUserId: String
 
     @EnvironmentObject var appViewModel: AppViewModel
     @State private var messages: [Message] = []
@@ -130,7 +131,8 @@ struct ChatView: View {
                 "lastMessage": message.text,
                 "lastMessageTimestamp": message.timestamp,
                 "lastMessageSenderId": currentUserId,
-                "readBy": [currentUserId]
+                "readBy": [currentUserId],
+                "visibleTo": FieldValue.arrayUnion([currentUserId, otherUserId])
             ])
             newMessage = ""
         } catch {

--- a/TheChopYard/ListingDetailView.swift
+++ b/TheChopYard/ListingDetailView.swift
@@ -48,7 +48,7 @@ struct ListingDetailView: View {
         }
         .navigationDestination(isPresented: $navigateToChat) {
             if let chatId = chatDocumentIdToNavigate {
-                ChatView(chatId: chatId, sellerUsername: sellerUsername)
+                ChatView(chatId: chatId, sellerUsername: sellerUsername, otherUserId: listing.sellerId)
                     .environmentObject(appViewModel)
             } else {
                 Text("Error: Could not open chat.")

--- a/TheChopYard/MessagesView.swift
+++ b/TheChopYard/MessagesView.swift
@@ -135,7 +135,7 @@ struct MessagesView: View {
             }
             .navigationTitle("Messages")
             .navigationDestination(for: ChatThread.self) { thread in
-                ChatView(chatId: thread.id, sellerUsername: thread.displayName)
+                ChatView(chatId: thread.id, sellerUsername: thread.displayName, otherUserId: thread.othersellerId)
                     .environmentObject(appViewModel)
             }
             .onAppear {


### PR DESCRIPTION
## Summary
- include `otherUserId` when creating `ChatView`
- update `sendMessage` to ensure all participants are added back to `visibleTo`
- pass seller id to `ChatView` when messaging from a listing
- pass other participant id from the messages list

## Testing
- `swift test -list` *(fails: Missing value for '-s <specifier>')*

------
https://chatgpt.com/codex/tasks/task_e_685623298eb4832c9083a3c051af2a72