### PR TITLE
Add location, notifications, and account deletion features

### DIFF
--- a/TheChopYard/Extensions.swift
+++ b/TheChopYard/Extensions.swift
@@ -15,4 +15,5 @@ extension Date {
 extension Notification.Name {
     static let listingUpdated = Notification.Name("listingUpdated")
     static let homeTabSelected = Notification.Name("homeTabSelected")
+    static let didReceiveFCMToken = Notification.Name("didReceiveFCMToken")
 }

--- a/TheChopYard/HomeFeedView.swift
+++ b/TheChopYard/HomeFeedView.swift
@@ -4,7 +4,7 @@ import FirebaseFirestore
 
 struct HomeFeedView: View {
     @EnvironmentObject var appViewModel: AppViewModel
-    @StateObject private var locationManager = LocationManager()
+    @EnvironmentObject var locationManager: LocationManager
 
     @State private var selectedRadius: Double = 210.0
     @State private var selectedCategories: Set<String> = []

--- a/TheChopYard/SavedListingView.swift
+++ b/TheChopYard/SavedListingView.swift
@@ -9,7 +9,7 @@ import CoreLocation
 
 struct SavedListingsView: View {
     @EnvironmentObject var appViewModel: AppViewModel
-    @StateObject private var locationManager = LocationManager()
+    @EnvironmentObject var locationManager: LocationManager
     @State private var savedListings: [Listing] = []
     @State private var isLoading = false
     @State private var errorAlertItem: ErrorAlertItem? // This will now refer to the shared definition


### PR DESCRIPTION
## Summary
- use a shared `LocationManager` so the app requests location on launch
- register for push notifications and handle FCM token updates
- store FCM tokens under each user and send them to the server when received
- allow users to delete their accounts in `ProfileView`
- cloud function sends push notifications for new chat messages

## Testing
- `npm ls` *(fails: missing packages / no internet)*

------
https://chatgpt.com/codex/tasks/task_e_685635c89380832c853e178c2a3aba04