### PR TITLE
Add location, push notifications, and account cleanup

### DIFF
--- a/TheChopYard/AppViewModel.swift
+++ b/TheChopYard/AppViewModel.swift
@@ -42,6 +42,14 @@ class AppViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        NotificationCenter.default.publisher(for: .didReceiveFCMToken)
+            .sink { [weak self] notification in
+                if let token = notification.object as? String {
+                    self?.updateFCMToken(token)
+                }
+            }
+            .store(in: &cancellables)
+
         self.authStateListenerHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
             guard let self else { return }
             Task { @MainActor in
@@ -210,8 +218,6 @@ class AppViewModel: ObservableObject {
                         let senderId = data["lastMessageSenderId"] as? String ?? ""
                         let chatId = doc.documentID
 
-                        print("🔍 Chat \(chatId): readBy=\(readBy), senderId=\(senderId), user=\(currentsellerId)")
-
                         if !readBy.contains(currentsellerId), senderId != currentsellerId {
                             hasUnread = true
                             break
@@ -221,7 +227,6 @@ class AppViewModel: ObservableObject {
 
                 DispatchQueue.main.async {
                     self.hasUnreadMessages = hasUnread
-                    print("🔴 hasUnreadMessages = \(hasUnread)")
                 }
             }
     }
@@ -229,6 +234,13 @@ class AppViewModel: ObservableObject {
     // 🔧 NEW: Used to remove a deleted listing from local savedListingIds
     func removeSavedListingId(_ id: String) {
         savedListingIds.remove(id)
+    }
+
+    func updateFCMToken(_ token: String) {
+        guard let uid = user?.uid else { return }
+        db.collection("users").document(uid).updateData([
+            "fcmTokens": FieldValue.arrayUnion([token])
+        ])
     }
 
     func updateListing(_ listing: Listing) {

--- a/TheChopYard/ErrorAlertItem.swift
+++ b/TheChopYard/ErrorAlertItem.swift
@@ -1,5 +1,4 @@
-// In AppUtilities.swift (or ErrorAlertItem.swift)
-import Foundation // For UUID
+import Foundation
 
 struct ErrorAlertItem: Identifiable {
     let id = UUID()

--- a/TheChopYard/Extensions.swift
+++ b/TheChopYard/Extensions.swift
@@ -15,4 +15,5 @@ extension Date {
 extension Notification.Name {
     static let listingUpdated = Notification.Name("listingUpdated")
     static let homeTabSelected = Notification.Name("homeTabSelected")
+    static let didReceiveFCMToken = Notification.Name("didReceiveFCMToken")
 }

--- a/TheChopYard/HomeFeedView.swift
+++ b/TheChopYard/HomeFeedView.swift
@@ -4,7 +4,7 @@ import FirebaseFirestore
 
 struct HomeFeedView: View {
     @EnvironmentObject var appViewModel: AppViewModel
-    @StateObject private var locationManager = LocationManager()
+    @EnvironmentObject var locationManager: LocationManager
 
     @State private var selectedRadius: Double = 210.0
     @State private var selectedCategories: Set<String> = []

--- a/TheChopYard/ProfileView.swift
+++ b/TheChopYard/ProfileView.swift
@@ -3,25 +3,18 @@ import FirebaseAuth
 import FirebaseFirestore
 import CoreLocation
 
-// NO ErrorAlertItem struct definition here anymore.
-// It will use the definition from AppUtilities.swift (or your shared file).
-
 @available(iOS 16.0, *)
 struct ProfileView: View {
     @EnvironmentObject var appViewModel: AppViewModel
+    @EnvironmentObject var locationManager: LocationManager
     @State private var userListings: [Listing] = []
     @State private var selectedListing: Listing?
     @State private var isLoading = true
     @State private var username: String = ""
     @State private var showingLogoutAlert = false
-    @State private var errorAlertItem: ErrorAlertItem? // This will now refer to the shared definition
+    @State private var errorAlertItem: ErrorAlertItem?
 
     private let db = Firestore.firestore()
-
-    // ... (rest of your ProfileView code remains the same as you provided in the last turn)
-    // The body, loadProfileData, fetchUsername, fetchUserListings methods
-    // DO NOT need to change again for this specific error.
-    // Just ensure the duplicate struct definition is removed from this file.
 
     var body: some View {
         NavigationStack {
@@ -52,6 +45,7 @@ struct ProfileView: View {
                         NavigationLink {
                             SavedListingsView()
                                 .environmentObject(appViewModel)
+                                .environmentObject(locationManager)
                         } label: {
                             Label("Saved Listings", systemImage: "heart")
                         }
@@ -153,4 +147,5 @@ struct ProfileView: View {
             self.errorAlertItem = ErrorAlertItem(message: "Could not load your listings: \(error.localizedDescription)")
         }
     }
+
 }

--- a/TheChopYard/SavedListingView.swift
+++ b/TheChopYard/SavedListingView.swift
@@ -1,23 +1,13 @@
-// SavedListingsView.swift
-
 import SwiftUI
 import FirebaseFirestore
 import CoreLocation
 
-// NO ErrorAlertItem struct definition here anymore.
-// It will use the definition from AppUtilities.swift (or your shared file).
-
 struct SavedListingsView: View {
     @EnvironmentObject var appViewModel: AppViewModel
-    @StateObject private var locationManager = LocationManager()
+    @EnvironmentObject var locationManager: LocationManager
     @State private var savedListings: [Listing] = []
     @State private var isLoading = false
-    @State private var errorAlertItem: ErrorAlertItem? // This will now refer to the shared definition
-
-    // ... (rest of your SavedListingsView code remains the same as you provided in the last turn)
-    // The body, listingsScrollView, fetchFullSavedListings, clientSideSortedListings methods
-    // DO NOT need to change again for this specific error.
-    // Just ensure the duplicate/commented-out struct definition is removed from this file.
+    @State private var errorAlertItem: ErrorAlertItem?
 
     var body: some View {
         NavigationView {

--- a/TheChopYard/SettingsView.swift
+++ b/TheChopYard/SettingsView.swift
@@ -10,6 +10,10 @@ struct SettingsView: View {
     @State private var isAvailable: Bool? = nil
     @State private var isSaving = false
     @State private var errorMessage = ""
+    @State private var showingDeleteAlert = false
+    @State private var errorAlertItem: ErrorAlertItem?
+
+    @EnvironmentObject var appViewModel: AppViewModel
 
     private let db = Firestore.firestore()
 
@@ -47,9 +51,27 @@ struct SettingsView: View {
                 }
                 .disabled(!canSave)
             }
+            Section {
+                Button(role: .destructive) {
+                    showingDeleteAlert = true
+                } label: {
+                    Text("Delete Account")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .foregroundColor(.red)
+                }
+            }
         }
         .navigationTitle("Settings")
         .onAppear(perform: validateUsername)
+        .alert("Delete Account", isPresented: $showingDeleteAlert) {
+            Button("Delete", role: .destructive) { deleteAccount() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will remove your account and listings permanently.")
+        }
+        .alert(item: $errorAlertItem) { item in
+            Alert(title: Text(item.title), message: Text(item.message), dismissButton: .default(Text("OK")))
+        }
     }
 
     private var canSave: Bool {
@@ -119,6 +141,17 @@ struct SettingsView: View {
                 } else {
                     onUsernameUpdated()
                 }
+            }
+        }
+    }
+
+    private func deleteAccount() {
+        guard let user = Auth.auth().currentUser else { return }
+        user.delete { error in
+            if let error = error {
+                self.errorAlertItem = ErrorAlertItem(message: "Failed to delete account: \(error.localizedDescription)")
+            } else {
+                appViewModel.signOutCurrentUser()
             }
         }
     }

--- a/TheChopYard/TheChopYardApp.swift
+++ b/TheChopYard/TheChopYardApp.swift
@@ -1,39 +1,67 @@
 import SwiftUI
 import FirebaseCore
 import FirebaseFirestore
-import FirebaseAnalytics //
+import FirebaseAnalytics
+import FirebaseMessaging
+import UserNotifications
 
-class AppDelegate: NSObject, UIApplicationDelegate { //
-    func application( //
+class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
+    func application(
         _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil //
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        // Configure Firebase
-        FirebaseApp.configure() //
-        
-        // Enable Firestore offline persistence
-        let db = Firestore.firestore() //
-        let settings = db.settings // Get current settings
-        settings.isPersistenceEnabled = true //
-        // settings.cacheSizeBytes = FirestoreCacheSizeUnlimited // Optional: for specific cache size
-        db.settings = settings //
+        FirebaseApp.configure()
 
-        // Optional: Log Firebase Analytics app open event
-        Analytics.logEvent(AnalyticsEventAppOpen, parameters: nil) //
+        // Firestore offline persistence
+        let db = Firestore.firestore()
+        let settings = db.settings
+        settings.isPersistenceEnabled = true
+        db.settings = settings
 
-        return true //
+        // Log app open
+        Analytics.logEvent(AnalyticsEventAppOpen, parameters: nil)
+
+        // Register for push notifications
+        UNUserNotificationCenter.current().delegate = self
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, _ in
+            if granted {
+                DispatchQueue.main.async { application.registerForRemoteNotifications() }
+            }
+        }
+
+        Messaging.messaging().delegate = self
+
+        return true
+    }
+
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        guard let token = fcmToken else { return }
+        NotificationCenter.default.post(name: .didReceiveFCMToken, object: token)
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .sound])
     }
 }
 
 @main
-struct TheChopYardApp: App { //
-    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate //
-    @StateObject private var appViewModel = AppViewModel() //
+struct TheChopYardApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    @StateObject private var appViewModel = AppViewModel()
+    @StateObject private var locationManager = LocationManager()
 
     var body: some Scene {
-        WindowGroup { //
+        WindowGroup {
             ContentView()
-                .environmentObject(appViewModel) //
+                .environmentObject(appViewModel)
+                .environmentObject(locationManager)
+                .onAppear {
+                    locationManager.requestPermissionAndFetchLocation()
+                }
         }
     }
 }


### PR DESCRIPTION
## Summary
- request location permission on launch via a shared `LocationManager`
- register for Firebase Messaging and handle FCM token updates in `AppDelegate`
- store device FCM tokens in Firestore for each user
- move the destructive account deletion option to `SettingsView`
- add Cloud Functions to clean up user data and send push notifications for new messages
- remove a stray comment in `ProfileView`

## Testing
- `npm --prefix functions ls` *(fails: missing packages / no internet)*

------
https://chatgpt.com/codex/tasks/task_e_685635c89380832c853e178c2a3aba04